### PR TITLE
ignore file pastes

### DIFF
--- a/lib/ace/keyboard/textinput.js
+++ b/lib/ace/keyboard/textinput.js
@@ -434,6 +434,9 @@ var TextInput = function(parentNode, host) {
     };
     
     var onPaste = function(e) {
+        if (isFilePaste(e)) {
+            return
+        }
         var data = handleClipboardData(e);
         if (clipboard.pasteCancelled())
             return;
@@ -449,6 +452,14 @@ var TextInput = function(parentNode, host) {
             pasted = true;
         }
     };
+
+    var isFilePaste = function(e) {
+        var clipboardData = e.clipboardData || window.clipboardData;
+        var items = clipboardData && clipboardData.items;
+        return Array.from(items).some(function(item) {
+            return item.kind === "file";
+        });
+    }
 
     event.addCommandKeyListener(text, host.onCommandKey.bind(host), host);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When handling paste events, simply ignore the event if we detect that the data being pasted is a file.  Note that the event is not cancelled, it is simply ignored.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
